### PR TITLE
Code Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "4.4"
+  - "0.12"
+
+install:
+  - npm install
+
+script:
+  - npm test

--- a/FORMATS.md
+++ b/FORMATS.md
@@ -1,0 +1,69 @@
+# Date formats
+
+<table>
+  <tr>
+    <th>day</th>
+    <td>2013-12-06</td>
+    <td><code>YYYY-MM-DD</code></td>
+  </tr>
+  <tr>
+    <th>time</th>
+    <td>15:22</td>
+    <td><code>HH:mm</code></td>
+  </tr>
+  <tr>
+    <th>dayTime</th>
+    <td>2013-12-06 15:22</td>
+    <td><code>YYYY-MM-DD HH:mm</code></td>
+  </tr>
+  <tr>
+    <th>iCalDay</th>
+    <td>20131206</td>
+    <td><code>YYYYMMDD</code></td>
+  </tr>
+  <tr>
+    <th>iCalTime</th>
+    <td>152207</td>
+    <td><code>HHmmss</code></td>
+  </tr>
+  <tr>
+    <th>iCalDayTime</th>
+    <td>20131206T152207</td>
+    <td><code>YYYYMMDD[T]HHmmss</code></td>
+  </tr>
+  <tr>
+    <th>slashDay</th>
+    <td>12/6/2013</td>
+    <td><code>M/D/YYYY</code></td>
+  </tr>
+  <tr>
+    <th>shortSlashDay</th>
+    <td>12/6</td>
+    <td><code>M/D</code></td>
+  </tr>
+  <tr>
+    <th>shortDay</th>
+    <td>Friday, Dec 6</td>
+    <td><code>dddd, MMM D</code></td>
+  </tr>
+  <tr>
+    <th>abbrvDay</th>
+    <td>Fri Dec 6</td>
+    <td><code>ddd MMM D</code></td>
+  </tr>
+  <tr>
+    <th>longDay</th>
+    <td>Friday, December 6, 2013</td>
+    <td><code>dddd, MMMM D, YYYY</code></td>
+  </tr>
+  <tr>
+    <th>weekday</th>
+    <td>Friday</td>
+    <td><code>dddd</code></td>
+  </tr>
+  <tr>
+    <th>unixDate</th>
+    <td>Fri Dec 06 2013 15:22:07</td>
+    <td><code>ddd MMM DD YYYY HH:mm:ss</code></td>
+  </tr>
+</table>

--- a/README.md
+++ b/README.md
@@ -30,80 +30,14 @@ geomoment.formats.day         = 'YYYY-MM-DD'    // 2013-01-01
 
 See also: [geomoment-angular](https://github.com/goodeggs/geomoment-angular) for use in an [angular.js](http://angularjs.org) project.
 
-## Date formats
-
-<table>
-  <tr>
-    <th>day</th>
-    <td>2013-12-06</td>
-    <td><code>YYYY-MM-DD</code></td>
-  </tr>
-  <tr>
-    <th>time</th>
-    <td>15:22</td>
-    <td><code>HH:mm</code></td>
-  </tr>
-  <tr>
-    <th>dayTime</th>
-    <td>2013-12-06 15:22</td>
-    <td><code>YYYY-MM-DD HH:mm</code></td>
-  </tr>
-  <tr>
-    <th>iCalDay</th>
-    <td>20131206</td>
-    <td><code>YYYYMMDD</code></td>
-  </tr>
-  <tr>
-    <th>iCalTime</th>
-    <td>152207</td>
-    <td><code>HHmmss</code></td>
-  </tr>
-  <tr>
-    <th>iCalDayTime</th>
-    <td>20131206T152207</td>
-    <td><code>YYYYMMDD[T]HHmmss</code></td>
-  </tr>
-  <tr>
-    <th>slashDay</th>
-    <td>12/6/2013</td>
-    <td><code>M/D/YYYY</code></td>
-  </tr>
-  <tr>
-    <th>shortSlashDay</th>
-    <td>12/6</td>
-    <td><code>M/D</code></td>
-  </tr>
-  <tr>
-    <th>shortDay</th>
-    <td>Friday, Dec 6</td>
-    <td><code>dddd, MMM D</code></td>
-  </tr>
-  <tr>
-    <th>abbrvDay</th>
-    <td>Fri Dec 6</td>
-    <td><code>ddd MMM D</code></td>
-  </tr>
-  <tr>
-    <th>longDay</th>
-    <td>Friday, December 6, 2013</td>
-    <td><code>dddd, MMMM D, YYYY</code></td>
-  </tr>
-  <tr>
-    <th>weekday</th>
-    <td>Friday</td>
-    <td><code>dddd</code></td>
-  </tr>
-  <tr>
-    <th>unixDate</th>
-    <td>Fri Dec 06 2013 15:22:07</td>
-    <td><code>ddd MMM DD YYYY HH:mm:ss</code></td>
-  </tr>
-</table>
-
 ## Dependencies
 
 Requires `moment-timezone` when you require `geomoment` but
 requires that your project explicitly includes `moment@2.9.0` or newer.
+
+## Date formats
+
+See the generated [date formats documentation](./FORMATS.md).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha --compilers coffee:coffee-script test/**/*.coffee",
-    "build": "coffee --bare --compile --output lib/ src/ && npm run document",
+    "build": "coffee --bare --compile --output lib/ src/",
+    "prepublish": "npm run document",
     "document": "coffee util/document_date_formats.coffee",
     "pretest": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -28,13 +28,12 @@
   },
   "devDependencies": {
     "moment": "2.14.1",
-    "moment-timezone": "^0.1.0",
     "falafel": "^0.3.1",
     "mocha": "~1.15.1",
     "coffee-script": "~1.6.3",
     "chai": "~1.8.1"
   },
   "dependencies": {
-    "moment-timezone": "^0.5.4"
+    "moment-timezone": "^0.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "moment": "2.14.1",
-    "falafel": "^0.3.1",
     "mocha": "~1.15.1",
     "coffee-script": "~1.6.3",
     "chai": "~1.8.1"

--- a/util/document_date_formats.coffee
+++ b/util/document_date_formats.coffee
@@ -3,23 +3,17 @@ path = require 'path'
 geomoment = require '..'
 
 now = geomoment new Date('Fri Dec 06 2013 15:22:07 GMT-0800 (PST)')
-filename = path.resolve(__dirname, '..', 'README.md')
+filename = path.resolve(__dirname, '..', 'FORMATS.md')
 
-readme = fs.readFileSync(filename, encoding: 'utf-8').split('\n')
-before = readme[0..readme.indexOf('## Date formats')]
-after = readme[readme.indexOf('## License')..]
-
-readme = before
-readme.push ''
-readme.push '<table>'
+docs = ['# Date formats']
+docs.push ''
+docs.push '<table>'
 for format, spec of geomoment.formats
-  readme.push '  <tr>'
-  readme.push "    <th>#{format}</th>"
-  readme.push "    <td>#{now.format(spec)}</td>"
-  readme.push "    <td><code>#{spec}</code></td>"
-  readme.push '  </tr>'
-readme.push '</table>'
-readme.push ''
-readme = readme.concat after
+  docs.push '  <tr>'
+  docs.push "    <th>#{format}</th>"
+  docs.push "    <td>#{now.format(spec)}</td>"
+  docs.push "    <td><code>#{spec}</code></td>"
+  docs.push '  </tr>'
+docs.push '</table>'
 
-fs.writeFile filename, readme.join('\n'), encoding: 'utf-8'
+fs.writeFile filename, docs.join('\n'), encoding: 'utf-8'


### PR DESCRIPTION
Synopsis:

We originally ran into a bug in production such that `isSame()` comparisons were very broken. It turned out this was a problem in old versions of geomoment which used old versions of moment < 2.14.0. See all the crazy comments below to get a glimpse of what we looked at.

While working on that I made several changes to clean up the code generally which I think are worth keeping:

 * Test against node 4.4, and 0.12 in Travis CI
 * Stop autogenerating the README: instead only do this during prepublish and use a different file, FORMATS.md.
 * Remove duplicate entry for moment-timezone in both dependencies and devDependencies
 * Remove unused dependency falafel

cc @serhalp @dannynelson @sylspren 